### PR TITLE
Retrieve the global ranking and display it

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -8,7 +8,7 @@
                 min-width: 160px;
                 text-align: center;
             }
-            #name {
+            #name, #rank {
                 font-size: 90%;
             }
             #rating {
@@ -22,7 +22,7 @@
                 height: 45px;
                 margin-top: 13px;
                 margin-bottom: 13px;
-                line-height: 45px;  
+                line-height: 45px;
                 vertical-align: middle;
                 display: none;
             }
@@ -48,11 +48,11 @@
             }
 
             @keyframes sk-rotateplane {
-                0% { 
+                0% {
                     transform: perspective(120px) rotateX(0deg) rotateY(0deg);
-                } 50% { 
+                } 50% {
                     transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg);
-                } 100% { 
+                } 100% {
                     transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);
                 }
             }
@@ -63,5 +63,6 @@
         <div id="spinner"></div>
         <div id="name"></div>
         <div id="rating"></div>
+        <div id="rank"></div>
   </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -42,16 +42,25 @@ function getRating(id) {
         if (this.readyState == 4) {
             var name = this.responseXML.getElementsByTagName("name")[0].attributes.value.nodeValue;
             var rating = this.responseXML.getElementsByTagName("average")[0].attributes.value.nodeValue;
+            var ranks = this.responseXML.getElementsByTagName("rank");
             var yearPublished = this.responseXML.getElementsByTagName("yearpublished")[0].attributes.value.nodeValue;
-            var type = this.responseXML.getElementsByTagName("item")[0].attributes.type.nodeValue; 
-            console.info("getRating(): %s (%s): %s", name, yearPublished, rating);
+            var type = this.responseXML.getElementsByTagName("item")[0].attributes.type.nodeValue;
+
+            var rank = 'Not found';
+            for (var i = 0; i < ranks.length; i += 1) {
+                if (ranks[i].attributes.name.nodeValue === "boardgame") {
+                    rank = ranks[i].attributes.value.nodeValue;
+                }
+            }
+
+            console.info("getRating(): %s (%s): %s - %s", name, yearPublished, rating, rank);
             hideSpinner();
-            displayResults(id, name, rating, yearPublished, type);
+            displayResults(id, name, rating, yearPublished, type, rank);
         }
     });
 }
 
-function displayResults(id, name, rating, yearPublished, type) {
+function displayResults(id, name, rating, yearPublished, type, rank) {
     var nameDiv = document.getElementById("name");
     nameDiv.textContent = "";
 
@@ -69,6 +78,10 @@ function displayResults(id, name, rating, yearPublished, type) {
     ratingDiv.textContent = ratingNum.toFixed(1);
     ratingDiv.classList.add("rating-" + ratingNum.toFixed(0));
     ratingDiv.style.display = "block";
+
+    var rankDiv = document.getElementById("rank");
+    rankDiv.textContent = "Ranking: " + rank;
+    rankDiv.style.display = "block";
 
     // This is to allow the hyperlink to work
     window.addEventListener('click', function(e) {


### PR DESCRIPTION
Hi Saulo.

I've added the global board game rank to the things it retrieves from the BGG and added it at the bottom of the popup.

Here there is an example:

![bgg chrome](https://cloud.githubusercontent.com/assets/535478/19450870/6ab11bbe-94ab-11e6-91c2-a48404ba9fa4.gif)
